### PR TITLE
Allow interpolation in clean

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='yapim',
-    version='0.3.1',
+    version='0.3.2',
     description='Pipeline generation tool',
     url='',
     author='Christopher Neely',

--- a/tests/executor/post_run_cleanup/tasks/task_with_cleanup.py
+++ b/tests/executor/post_run_cleanup/tasks/task_with_cleanup.py
@@ -19,9 +19,9 @@ class TaskWithCleanup(Task):
     def depends() -> List[DependencyInput]:
         pass
 
-    @clean("wdir", "*tmp.out")
+    @clean("wdir", "*tmp.out", "{self.record_id}.deferred.out")
     def run(self):
         touch(self.output["retained_files"])
         touch(self.wdir.joinpath(f"{self.record_id}tmp.out"))
+        touch(self.wdir.joinpath(f"{self.record_id}.deferred.out"))
         os.mkdir(self.wdir.joinpath("wdir"))
-

--- a/tests/executor/test_executor.py
+++ b/tests/executor/test_executor.py
@@ -278,6 +278,9 @@ class TestExecutor(unittest.TestCase):
         deleted_files = glob.glob(
             str(out_dir.joinpath("wdir").joinpath("*").joinpath("TaskWithCleanup").joinpath("*tmp.out")))
         assert len(deleted_files) == 0
+        deferred_files = glob.glob(
+            str(out_dir.joinpath("wdir").joinpath("*").joinpath("TaskWithCleanup").joinpath("*.deferred.out")))
+        assert len(deferred_files) == 0
 
 
 if __name__ == '__main__':

--- a/yapim/__init__.py
+++ b/yapim/__init__.py
@@ -1,8 +1,9 @@
 """Yet Another PIpeline Manager"""
 from yapim.tasks.aggregate_task import AggregateTask
-from yapim.tasks.task import Task, clean
+from yapim.tasks.task import Task
 from yapim.tasks.task import TaskExecutionError
 from yapim.tasks.task import TaskSetupError
+from yapim.tasks.utils.clean import clean
 from yapim.tasks.utils.dependency_input import DependencyInput
 from yapim.tasks.utils.result import Result
 from yapim.tasks.utils.version_info import VersionInfo

--- a/yapim/tasks/task.py
+++ b/yapim/tasks/task.py
@@ -1,14 +1,12 @@
 """Task provides the primary API methods with which users will interact."""
-import glob
 import logging
 import os
-import shutil
 import threading
 import time
 import traceback
 from abc import ABC
 from pathlib import Path
-from typing import Tuple, List, Union, Optional, Callable
+from typing import Tuple, List, Union, Optional
 
 # pylint: disable=no-member
 from plumbum import local, colors, ProcessExecutionError
@@ -33,37 +31,6 @@ class TaskExecutionError(RuntimeError):
     Wrapper for error within running a task associated with an error in config lookup or other utility- or setup-
     related issues
     """
-
-
-def clean(*paths: Union[Path, str]):
-    """
-    Remove files/directories in this Task's working directory after run() completes
-
-    Example:
-        @clean("tmp", "a*.out")
-
-    Prior to performing delete operation, each path is concatenated with the record's working directory:
-        glob.glob(self.wdir.joinpath(path))
-
-    :param paths: Relative paths to remove
-    :return:
-    """
-
-    def method(func: Callable):
-        def fxn(self):
-            func(self)
-            for glob_path in paths:
-                for out_fd in glob.glob(str(self.wdir.joinpath(glob_path))):
-                    out_fd = Path(out_fd).resolve()
-                    if out_fd.exists():
-                        if out_fd.is_dir():
-                            shutil.rmtree(out_fd, ignore_errors=True)
-                        else:
-                            os.remove(out_fd)
-
-        return fxn
-
-    return method
 
 
 # pylint: disable=line-too-long,fixme

--- a/yapim/tasks/utils/clean.py
+++ b/yapim/tasks/utils/clean.py
@@ -1,0 +1,58 @@
+"""Utilities to manage removal of temporarily-created data"""
+import os
+import shutil
+from glob import glob
+from inspect import currentframe
+from pathlib import Path
+from typing import Union, Callable
+
+
+# pylint: disable=too-few-public-methods
+class _DeferredFString:
+    """
+    Defer execution of f-string to allow for API-provided + unevaluated templates
+
+    See:
+    https://stackoverflow.com/questions/42497625/how-to-postpone-defer-the-evaluation-of-f-strings
+    """
+    def __init__(self, payload: str):
+        self.payload = payload
+
+    def __str__(self):
+        _vars = currentframe().f_back.f_globals.copy()
+        _vars.update(currentframe().f_back.f_locals)
+        return self.payload.format(**_vars)
+
+
+def clean(*paths: Union[Path, str]):
+    """
+    Remove files/directories in this Task's working directory after run() completes
+
+    Example:
+        @clean("tmp", "a*.out", "{self.record_id}.tmp.out")
+
+    Note that strings will be interpolated as deferred f-strings
+
+    Prior to performing delete operation, each path is concatenated with the record's working directory:
+        glob.glob(self.wdir.joinpath(path))
+
+    :param paths: Relative paths to remove
+    :return:
+    """
+
+    def method(func: Callable):
+        def fxn(self):
+            func(self)
+            for templated_path in paths:
+                glob_path = _DeferredFString(templated_path)
+                for out_fd in glob(str(self.wdir.joinpath(str(glob_path)))):
+                    out_fd = Path(out_fd).resolve()
+                    if out_fd.exists():
+                        if out_fd.is_dir():
+                            shutil.rmtree(out_fd, ignore_errors=True)
+                        else:
+                            os.remove(out_fd)
+
+        return fxn
+
+    return method

--- a/yapim/yapim
+++ b/yapim/yapim
@@ -23,7 +23,7 @@ class YAPIM(cli.Application):
     """
     Create and run Yet Another PIpeline (Manager)
     """
-    VERSION = "0.3.1"
+    VERSION = "0.3.2"
 
     def main(self, *args):
         if args:


### PR DESCRIPTION
Previous `clean` function did not allow for easy interpolation

Fix
===
Simple evaluation (without use of `eval`) to allow for statements such as:

```python
@clean("wdir", "*tmp.out", "{self.record_id}.deferred.out")
def run(self): ...
```