### PR TITLE
Allow 'Path' in clean

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='yapim',
-    version='0.3.2',
+    version='0.3.3',
     description='Pipeline generation tool',
     url='',
     author='Christopher Neely',

--- a/tests/executor/post_run_cleanup/tasks/task_with_cleanup.py
+++ b/tests/executor/post_run_cleanup/tasks/task_with_cleanup.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import List, Union, Type
 
 from yapim import Task, DependencyInput, touch, clean
@@ -19,9 +20,12 @@ class TaskWithCleanup(Task):
     def depends() -> List[DependencyInput]:
         pass
 
-    @clean("wdir", "*tmp.out", "{self.record_id}.deferred.out")
+    @clean("wdir", "*tmp.out", "{self.record_id}.deferred.out", Path("keep").joinpath("file.out"))
     def run(self):
         touch(self.output["retained_files"])
         touch(self.wdir.joinpath(f"{self.record_id}tmp.out"))
         touch(self.wdir.joinpath(f"{self.record_id}.deferred.out"))
         os.mkdir(self.wdir.joinpath("wdir"))
+        keep_dir = self.wdir.joinpath("keep")
+        os.mkdir(keep_dir)
+        touch(keep_dir.joinpath("file.out"))

--- a/tests/executor/post_run_cleanup/tasks/task_with_cleanup.py
+++ b/tests/executor/post_run_cleanup/tasks/task_with_cleanup.py
@@ -20,7 +20,11 @@ class TaskWithCleanup(Task):
     def depends() -> List[DependencyInput]:
         pass
 
-    @clean("wdir", "*tmp.out", "{self.record_id}.deferred.out", Path("keep").joinpath("file.out"))
+    @clean("wdir",
+           "*tmp.out",
+           "{self.record_id}.deferred.out",
+           Path("keep").joinpath("file.out"),
+           Path("keep").joinpath("{self.record_id}.deferred.out"))
     def run(self):
         touch(self.output["retained_files"])
         touch(self.wdir.joinpath(f"{self.record_id}tmp.out"))
@@ -29,3 +33,4 @@ class TaskWithCleanup(Task):
         keep_dir = self.wdir.joinpath("keep")
         os.mkdir(keep_dir)
         touch(keep_dir.joinpath("file.out"))
+        touch(keep_dir.joinpath(f"{self.record_id}.deferred.out"))

--- a/tests/executor/test_executor.py
+++ b/tests/executor/test_executor.py
@@ -281,12 +281,13 @@ class TestExecutor(unittest.TestCase):
         deferred_files = glob.glob(
             str(out_dir.joinpath("wdir").joinpath("*").joinpath("TaskWithCleanup").joinpath("*.deferred.out")))
         assert len(deferred_files) == 0
-        partially_kept = glob.glob(
-            str(out_dir.joinpath("wdir").joinpath("*").joinpath("TaskWithCleanup").joinpath("keep")))
+        keep_path = out_dir.joinpath("wdir").joinpath("*").joinpath("TaskWithCleanup").joinpath("keep")
+        partially_kept = glob.glob(str(keep_path))
         assert len(partially_kept) == 10
-        removed_from_partially_kept = glob.glob(
-            str(out_dir.joinpath("wdir").joinpath("*").joinpath("TaskWithCleanup").joinpath("keep").joinpath("file.out")))
+        removed_from_partially_kept = glob.glob(str(keep_path.joinpath("file.out")))
         assert len(removed_from_partially_kept) == 0
+        deferred_removed_from_partially_kept = glob.glob(str(keep_path.joinpath("*.deferred.out")))
+        assert len(deferred_removed_from_partially_kept) == 0
 
 
 if __name__ == '__main__':

--- a/tests/executor/test_executor.py
+++ b/tests/executor/test_executor.py
@@ -281,6 +281,12 @@ class TestExecutor(unittest.TestCase):
         deferred_files = glob.glob(
             str(out_dir.joinpath("wdir").joinpath("*").joinpath("TaskWithCleanup").joinpath("*.deferred.out")))
         assert len(deferred_files) == 0
+        partially_kept = glob.glob(
+            str(out_dir.joinpath("wdir").joinpath("*").joinpath("TaskWithCleanup").joinpath("keep")))
+        assert len(partially_kept) == 10
+        removed_from_partially_kept = glob.glob(
+            str(out_dir.joinpath("wdir").joinpath("*").joinpath("TaskWithCleanup").joinpath("keep").joinpath("file.out")))
+        assert len(removed_from_partially_kept) == 0
 
 
 if __name__ == '__main__':

--- a/yapim/tasks/utils/clean.py
+++ b/yapim/tasks/utils/clean.py
@@ -15,8 +15,8 @@ class _DeferredFString:
     See:
     https://stackoverflow.com/questions/42497625/how-to-postpone-defer-the-evaluation-of-f-strings
     """
-    def __init__(self, payload: str):
-        self.payload = payload
+    def __init__(self, payload: Union[Path, str]):
+        self.payload = str(payload)
 
     def __str__(self):
         _vars = currentframe().f_back.f_globals.copy()
@@ -28,8 +28,8 @@ def clean(*paths: Union[Path, str]):
     """
     Remove files/directories in this Task's working directory after run() completes
 
-    Example:
-        @clean("tmp", "a*.out", "{self.record_id}.tmp.out")
+    Examples:
+        @clean("tmp", "a*.out", "{self.record_id}.tmp.out", Path("dd").joinpath("tmp.out"))
 
     Note that strings will be interpolated as deferred f-strings
 

--- a/yapim/yapim
+++ b/yapim/yapim
@@ -23,7 +23,7 @@ class YAPIM(cli.Application):
     """
     Create and run Yet Another PIpeline (Manager)
     """
-    VERSION = "0.3.2"
+    VERSION = "0.3.3"
 
     def main(self, *args):
         if args:


### PR DESCRIPTION
Error
=====
Improper handling of `Path` types in `@clean` 

Fix
===
`Path` is converted to `str` prior to performing formatting